### PR TITLE
Implement group membership UI with authentication

### DIFF
--- a/backend/app/Http/Controllers/API/GroupMessageController.php
+++ b/backend/app/Http/Controllers/API/GroupMessageController.php
@@ -13,7 +13,8 @@ class GroupMessageController extends Controller
 {
   public function __construct()
   {
-    $this->middleware(['auth:sanctum', 'premium-required']);
+    // プレミアム要求を削除して、認証のみ必要
+    $this->middleware(['auth:sanctum']);
   }
 
   public function index(Group $group)

--- a/frontend/pages/friends/index.vue
+++ b/frontend/pages/friends/index.vue
@@ -5,8 +5,51 @@
       style="height: calc(100vh - 7.5rem)"
     >
       <div class="flex h-full w-full">
-        <!-- メインコンテンツ -->
-        <div class="w-full overflow-y-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
+        <!-- ゲストユーザー制限メッセージ -->
+        <div v-if="!authStore.isAuthenticated" class="w-full overflow-y-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
+          <div class="max-w-2xl mx-auto">
+            <div class="bg-white rounded-xl shadow-sm p-8 text-center">
+              <div class="h-16 w-16 bg-yellow-100 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-8 w-8 text-yellow-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                  />
+                </svg>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 mb-4">友達機能はご利用いただけません</h2>
+              <p class="text-gray-600 mb-6">
+                ゲストユーザーは友達機能をご利用いただけません。<br>
+                友達機能をご利用いただくには、アカウント登録またはログインが必要です。
+              </p>
+              <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <NuxtLink
+                  to="/auth/register"
+                  class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors"
+                >
+                  アカウント登録
+                </NuxtLink>
+                <NuxtLink
+                  to="/auth/login"
+                  class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+                >
+                  ログイン
+                </NuxtLink>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- メインコンテンツ (認証済みユーザーのみ) -->
+        <div v-else class="w-full overflow-y-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-8">
           <div v-if="loading" class="flex justify-center items-center py-20">
             <div class="text-center">
               <div
@@ -502,8 +545,12 @@ import { ref, onMounted, watch } from "vue";
 import { useApi } from "../../composables/useApi";
 import { useToast } from "../../composables/useToast";
 import { useRouter } from "vue-router";
+import { useAuthStore } from "../../stores/auth";
 import { formatDistanceToNow } from "date-fns";
 import { ja } from "date-fns/locale";
+
+// 認証ストア
+const authStore = useAuthStore();
 
 // 型定義
 interface User {

--- a/frontend/pages/join/[token].vue
+++ b/frontend/pages/join/[token].vue
@@ -1,81 +1,350 @@
 <template>
-  <div class="p-4 max-w-md mx-auto">
-    <h1 class="text-xl font-bold mb-4">グループ参加</h1>
-    <div
-      v-if="successMessage"
-      class="mb-4 p-3 bg-green-100 border border-green-400 text-green-700 rounded"
-    >
-      {{ successMessage }}
-    </div>
-    <div
-      v-if="errorMessage"
-      class="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded"
-    >
-      {{ errorMessage }}
-    </div>
-    <div class="mb-4">
-      <label for="nickname" class="block text-sm font-medium mb-1"
-        >ニックネーム</label
+  <div class="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+    <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
+      <div class="text-center mb-8">
+        <h1 class="text-2xl font-bold text-gray-900 mb-2">グループへ参加</h1>
+        <p class="text-gray-600">参加方法を選択してください</p>
+      </div>
+
+      <!-- エラーメッセージ -->
+      <div
+        v-if="errorMessage"
+        class="mb-6 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg"
       >
-      <input
-        id="nickname"
-        v-model="nickname"
-        type="text"
-        class="border rounded px-3 py-2 w-full"
-        placeholder="ニックネーム"
-      />
+        {{ errorMessage }}
+      </div>
+
+      <!-- 成功メッセージ -->
+      <div
+        v-if="successMessage"
+        class="mb-6 p-4 bg-green-100 border border-green-400 text-green-700 rounded-lg"
+      >
+        {{ successMessage }}
+      </div>
+
+      <!-- 選択状態 -->
+      <div v-if="!selectedOption" class="space-y-4">
+        <!-- アカウントをお持ちの方 -->
+        <button
+          @click="selectAccountLogin"
+          class="w-full p-4 border-2 border-gray-200 rounded-lg hover:border-blue-500 hover:bg-blue-50 transition-colors"
+        >
+          <div class="flex items-center justify-between">
+            <div class="text-left">
+              <h3 class="font-semibold text-gray-900">アカウントをお持ちの方</h3>
+              <p class="text-sm text-gray-600">ログインしてチャットリストに追加</p>
+            </div>
+            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+          </div>
+        </button>
+
+        <!-- ゲストとして続ける方 -->
+        <button
+          @click="selectGuestLogin"
+          class="w-full p-4 border-2 border-gray-200 rounded-lg hover:border-green-500 hover:bg-green-50 transition-colors"
+        >
+          <div class="flex items-center justify-between">
+            <div class="text-left">
+              <h3 class="font-semibold text-gray-900">ゲストとして続ける方</h3>
+              <p class="text-sm text-gray-600">すぐにチャットを開始</p>
+            </div>
+            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+          </div>
+        </button>
+      </div>
+
+      <!-- ログインフォーム -->
+      <div v-if="selectedOption === 'account'" class="space-y-6">
+        <div class="flex items-center mb-4">
+          <button
+            @click="goBack"
+            class="mr-3 p-1 text-gray-500 hover:text-gray-700"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+            </svg>
+          </button>
+          <h2 class="text-lg font-semibold text-gray-900">ログイン</h2>
+        </div>
+
+        <!-- 通常ログインフォーム -->
+        <form @submit.prevent="loginAndJoin" class="space-y-4">
+          <div>
+            <label for="email" class="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              v-model="loginForm.email"
+              type="email"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="メールアドレス"
+            />
+          </div>
+          <div>
+            <label for="password" class="block text-sm font-medium text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              id="password"
+              v-model="loginForm.password"
+              type="password"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="パスワード"
+            />
+          </div>
+          <button
+            type="submit"
+            :disabled="loginPending"
+            class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {{ loginPending ? "ログイン中..." : "ログインして参加" }}
+          </button>
+        </form>
+
+        <!-- Googleログイン -->
+        <div class="relative">
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-gray-300" />
+          </div>
+          <div class="relative flex justify-center text-sm">
+            <span class="px-2 bg-white text-gray-500">または</span>
+          </div>
+        </div>
+
+        <button
+          @click="googleLoginAndJoin"
+          :disabled="loginPending"
+          class="w-full flex justify-center items-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+        >
+          <svg class="w-5 h-5 mr-3" viewBox="0 0 24 24">
+            <path
+              fill="#4285F4"
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            />
+            <path
+              fill="#34A853"
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            />
+            <path
+              fill="#EA4335"
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            />
+          </svg>
+          Googleでログインして参加
+        </button>
+
+        <div class="text-center text-sm text-gray-600">
+          <p>
+            アカウントをお持ちでないですか？
+            <NuxtLink
+              to="/auth/register"
+              class="font-medium text-blue-600 hover:text-blue-500"
+            >
+              アカウント登録
+            </NuxtLink>
+          </p>
+        </div>
+      </div>
+
+      <!-- ゲストフォーム -->
+      <div v-if="selectedOption === 'guest'" class="space-y-6">
+        <div class="flex items-center mb-4">
+          <button
+            @click="goBack"
+            class="mr-3 p-1 text-gray-500 hover:text-gray-700"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+            </svg>
+          </button>
+          <h2 class="text-lg font-semibold text-gray-900">ゲストとして参加</h2>
+        </div>
+
+        <div>
+          <label for="nickname" class="block text-sm font-medium text-gray-700 mb-1">
+            ニックネーム
+          </label>
+          <input
+            id="nickname"
+            v-model="nickname"
+            type="text"
+            required
+            maxlength="50"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+            placeholder="ニックネームを入力"
+          />
+        </div>
+
+        <button
+          @click="joinAsGuest"
+          :disabled="guestPending || !nickname.trim()"
+          class="w-full py-2 px-4 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ guestPending ? "参加中..." : "ゲストとして参加" }}
+        </button>
+
+        <div class="text-sm text-yellow-600 bg-yellow-50 p-3 rounded-md">
+          <p class="font-medium mb-1">ゲスト参加の制限</p>
+          <ul class="text-xs space-y-1">
+            <li>• 友達機能は利用できません</li>
+            <li>• ユーザー設定が一部制限されます</li>
+            <li>• このチャットのみ利用可能です</li>
+          </ul>
+        </div>
+      </div>
     </div>
-    <button
-      class="px-4 py-2 bg-emerald-600 text-white rounded disabled:opacity-50"
-      :disabled="pending"
-      @click="joinGroup"
-    >
-      {{ pending ? "参加中..." : "参加する" }}
-    </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, reactive } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useApi } from "~/composables/useApi";
+import { useAuthStore } from "~/stores/auth";
 import type { GroupMember } from "~/types/group";
 
 const route = useRoute();
 const router = useRouter();
 const { api } = useApi();
+const authStore = useAuthStore();
 
 const token = route.params.token as string;
 
-const nickname = ref("");
-const pending = ref(false);
+// UI状態
+const selectedOption = ref<'account' | 'guest' | null>(null);
 const errorMessage = ref("");
 const successMessage = ref("");
 
-const joinGroup = async () => {
+// ログインフォーム
+const loginForm = reactive({
+  email: "",
+  password: "",
+});
+const loginPending = ref(false);
+
+// ゲストフォーム
+const nickname = ref("");
+const guestPending = ref(false);
+
+// 選択肢の処理
+const selectAccountLogin = () => {
+  selectedOption.value = 'account';
+  errorMessage.value = "";
+};
+
+const selectGuestLogin = () => {
+  selectedOption.value = 'guest';
+  errorMessage.value = "";
+};
+
+const goBack = () => {
+  selectedOption.value = null;
   errorMessage.value = "";
   successMessage.value = "";
+};
+
+// グループ参加処理
+const joinGroup = async (isLoggedIn: boolean) => {
+  errorMessage.value = "";
+  
+  if (isLoggedIn) {
+    loginPending.value = true;
+  } else {
+    guestPending.value = true;
+  }
+
+  try {
+    const requestBody = {
+      nickname: isLoggedIn ? authStore.user?.name || "ユーザー" : nickname.value,
+    };
+
+    const member = await api<GroupMember>(`/groups/join/${token}`, {
+      method: "POST",
+      body: requestBody,
+    });
+
+    successMessage.value = "グループに参加しました";
+    
+    // 参加成功後のリダイレクト
+    if (isLoggedIn) {
+      // ログインユーザーはチャット一覧に追加される
+      router.push("/chat");
+    } else {
+      // ゲストは直接チャットルームへ
+      router.push(`/chat/${member.group_id}`);
+    }
+  } catch (error: any) {
+    console.error("参加エラー:", error);
+    if (error.data?.message) {
+      errorMessage.value = error.data.message;
+    } else {
+      errorMessage.value = "参加に失敗しました";
+    }
+  } finally {
+    loginPending.value = false;
+    guestPending.value = false;
+  }
+};
+
+// ログインして参加
+const loginAndJoin = async () => {
+  errorMessage.value = "";
+  loginPending.value = true;
+
+  try {
+    // ログイン処理
+    const loginResult = await authStore.login(loginForm.email, loginForm.password);
+    
+    if (!loginResult.success) {
+      errorMessage.value = loginResult.message || "ログインに失敗しました";
+      return;
+    }
+
+    // グループ参加処理
+    await joinGroup(true);
+  } catch (error) {
+    console.error("ログインエラー:", error);
+    errorMessage.value = "ログイン処理中にエラーが発生しました";
+  } finally {
+    loginPending.value = false;
+  }
+};
+
+// Googleログインして参加
+const googleLoginAndJoin = () => {
+  // グループトークンをセッションストレージに保存
+  sessionStorage.setItem('pendingGroupToken', token);
+  // Googleログインを開始
+  authStore.startGoogleLogin();
+};
+
+// ゲストとして参加
+const joinAsGuest = async () => {
   if (!nickname.value.trim()) {
     errorMessage.value = "ニックネームを入力してください";
     return;
   }
-  if (nickname.value.length > 50) {
-    errorMessage.value = "ニックネームは50文字以内で入力してください";
-    return;
-  }
-  pending.value = true;
-  try {
-    const member = await api<GroupMember>(`/groups/join/${token}`, {
-      method: "POST",
-      body: { nickname: nickname.value },
-    });
-    successMessage.value = "グループに参加しました";
-    router.push(`/user/groups/${member.group_id}/chat`);
-  } catch (e) {
-    console.error(e);
-    errorMessage.value = "参加に失敗しました";
-  } finally {
-    pending.value = false;
-  }
+  
+  await joinGroup(false);
 };
+
+// Googleログインからの復帰処理
+if (process.client) {
+  const pendingToken = sessionStorage.getItem('pendingGroupToken');
+  if (pendingToken === token && authStore.isAuthenticated) {
+    sessionStorage.removeItem('pendingGroupToken');
+    joinGroup(true);
+  }
+}
 </script>

--- a/frontend/pages/user/index.vue
+++ b/frontend/pages/user/index.vue
@@ -5,7 +5,82 @@
       style="height: calc(100vh - 7.5rem)"
     >
       <div class="flex h-full w-full">
-        <div class="w-full overflow-y-auto">
+        <!-- ゲストユーザー制限メッセージ -->
+        <div v-if="!authStore.isAuthenticated" class="w-full overflow-y-auto">
+          <div class="max-w-2xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+            <div class="bg-white rounded-xl shadow-sm p-8 text-center">
+              <div class="h-16 w-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-8 w-8 text-blue-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+              <h2 class="text-2xl font-bold text-gray-900 mb-4">ユーザー設定は制限されています</h2>
+              <p class="text-gray-600 mb-6">
+                ゲストユーザーはユーザー設定の一部機能が制限されています。<br>
+                すべての機能をご利用いただくには、アカウント登録またはログインが必要です。
+              </p>
+              
+              <!-- ゲスト向け限定メニュー -->
+              <div class="mb-8">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">ご利用可能な機能</h3>
+                <div class="grid gap-4">
+                  <NuxtLink to="/chat" class="block">
+                    <div class="bg-green-50 border border-green-200 rounded-lg p-4 hover:bg-green-100 transition-colors">
+                      <div class="flex items-center justify-center">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          class="h-6 w-6 text-green-600 mr-3"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"
+                          />
+                          <path
+                            d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"
+                          />
+                        </svg>
+                        <div>
+                          <h4 class="font-semibold text-green-800">チャット機能</h4>
+                          <p class="text-sm text-green-700">参加済みのグループチャットを利用できます</p>
+                        </div>
+                      </div>
+                    </div>
+                  </NuxtLink>
+                </div>
+              </div>
+
+              <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <NuxtLink
+                  to="/auth/register"
+                  class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors"
+                >
+                  アカウント登録
+                </NuxtLink>
+                <NuxtLink
+                  to="/auth/login"
+                  class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+                >
+                  ログイン
+                </NuxtLink>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- メインコンテンツ (認証済みユーザーのみ) -->
+        <div v-else class="w-full overflow-y-auto">
           <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
             <div v-if="isLoading" class="py-16 text-center">
               <!-- ローディングスピナー -->


### PR DESCRIPTION
A new group membership flow was implemented, removing premium requirements and differentiating between authenticated and guest users.

*   The `frontend/pages/join/[token].vue` page was refactored to present a single UI for joining, offering "Account Login" (including Google) or "Continue as Guest" options.
*   Backend changes in `backend/app/Http/Controllers/API/GroupController.php` removed the premium plan check for group joining. Guest users are now identified by a `null` `user_id` in `GroupMember` and have nickname uniqueness enforced.
*   The `premium-required` middleware was removed from `backend/app/Http/Controllers/API/GroupMessageController.php`, allowing all members to send messages.
*   Guest user functionality is restricted:
    *   `frontend/pages/friends/index.vue` displays a restriction message.
    *   `frontend/pages/user/index.vue` shows limited options with a restriction message.
    *   `frontend/pages/chat/index.vue` displays a guest-specific message, hiding the chat list for unauthenticated users.
*   Google login via `frontend/pages/auth/google/callback.vue` now integrates with the group join process, using `sessionStorage` to persist the group token.

This enables free group participation with distinct access levels for authenticated members and guests.